### PR TITLE
Convert manifest to yml and cleanup some redundancies

### DIFF
--- a/net.redeclipse.RedEclipse-Legacy.yml
+++ b/net.redeclipse.RedEclipse-Legacy.yml
@@ -11,27 +11,23 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --persist=.redeclipse
-  modules:
-        {
-            "name": "redeclipse",
-            "buildsystem": "cmake-ninja",
-            "no-make-install": true,
-            "subdir": "src",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/redeclipse/base/releases/download/v1.6.0/redeclipse_1.6.0_nix.tar.bz2",
-                    "sha256": "48a947e858587116b7d177cf18148d0d9e40b1c5b481e2c955baed68cffc2849"
-                },
-                {
-                    "type": "file",
-                    "path": "net.redeclipse.RedEclipse-Legacy.appdata.xml"
-                },
-                {
-                    "type": "file",
-                    "url": "https://raw.githubusercontent.com/redeclipse/base/master/src/install/nix/redeclipse.desktop.am",
-                    "sha256": "8060b6cfb23ebb191da0b3aa8267b156f0a3812ed7fea9266efecacbc9c962fe",
-                    "dest-filename": "redeclipse.desktop"
+modules:
+
+  - name: redeclipse
+    buildsystem: cmake-ninja
+    no-make-install: true
+    subdir: src
+    sources:
+      - type: archive
+        url: https://github.com/redeclipse/base/releases/download/v1.6.0/redeclipse_1.6.0_nix.tar.bz2
+        sha256: 48a947e858587116b7d177cf18148d0d9e40b1c5b481e2c955baed68cffc2849
+      - type: file
+        url: https://raw.githubusercontent.com/redeclipse/base/master/src/install/nix/redeclipse.desktop.am
+        sha256: 8060b6cfb23ebb191da0b3aa8267b156f0a3812ed7fea9266efecacbc9c962fe
+        dest-filename: redeclipse.desktop
+      - type: file
+        path: net.redeclipse.RedEclipse-Legacy.appdata.xml
+                    "
                 },
                 {
                     "type": "file",

--- a/net.redeclipse.RedEclipse-Legacy.yml
+++ b/net.redeclipse.RedEclipse-Legacy.yml
@@ -27,26 +27,17 @@ modules:
         dest-filename: redeclipse.desktop
       - type: file
         path: net.redeclipse.RedEclipse-Legacy.appdata.xml
-                    "
-                },
-                {
-                    "type": "file",
-                    "path": "redeclipse.sh"
-                }
-            ],
-            "post-install": [
-                "install -Dm755 ../redeclipse.sh /app/bin/redeclipse",
-                "install -Dm755 redeclipse_linux /app/share/redeclipse/redeclipse",
-                "install -Dm755 redeclipse_server_linux /app/share/redeclipse/redeclipse_server",
-                "install -Dm755 genkey_linux /app/share/redeclipse/genkey",
-                "cp -r ../config /app/share/redeclipse/",
-                "cp -r ../data /app/share/redeclipse/",
-                "cp -r ../doc /app/share/redeclipse/",
-                "install -Dm644 ../net.redeclipse.RedEclipse-Legacy.appdata.xml /app/share/appdata/net.redeclipse.RedEclipse-Legacy.appdata.xml",
-                "install -Dm644 ../redeclipse.desktop /app/share/applications/net.redeclipse.RedEclipse-Legacy.desktop",
-                "install -Dm644 ../src/install/nix/redeclipse_x128.png /app/share/icons/hicolor/128x128/apps/net.redeclipse.RedEclipse-Legacy.png",
-                "desktop-file-edit --set-name=\"Red Eclipse Legacy\" --set-icon=net.redeclipse.RedEclipse-Legacy --set-key=Exec --set-value=redeclipse /app/share/applications/net.redeclipse.RedEclipse-Legacy.desktop"
-        ]
-        }
-    ]
-}
+      - type: file
+        path: redeclipse.sh
+    post-install:
+      - install -Dm755 ../redeclipse.sh /app/bin/redeclipse
+      - install -Dm755 redeclipse_linux /app/share/redeclipse/redeclipse
+      - rm redeclipse_server_linux
+      - rm genkey_linux
+      - cp -r ../config /app/share/redeclipse/
+      - cp -r ../data /app/share/redeclipse/
+      - rm -r ../doc
+      - install -Dm644 ../net.redeclipse.RedEclipse-Legacy.appdata.xml /app/share/appdata/net.redeclipse.RedEclipse-Legacy.appdata.xml
+      - install -Dm644 ../redeclipse.desktop /app/share/applications/net.redeclipse.RedEclipse-Legacy.desktop
+      - install -Dm644 ../src/install/nix/redeclipse_x128.png /app/share/icons/hicolor/128x128/apps/net.redeclipse.RedEclipse-Legacy.png
+      - desktop-file-edit --set-name=\"Red Eclipse Legacy\" --set-icon=net.redeclipse.RedEclipse-Legacy --set-key=Exec --set-value=redeclipse /app/share/applications/net.redeclipse.RedEclipse-Legacy.desktop

--- a/net.redeclipse.RedEclipse-Legacy.yml
+++ b/net.redeclipse.RedEclipse-Legacy.yml
@@ -1,27 +1,17 @@
-{
-    "app-id": "net.redeclipse.RedEclipse-Legacy",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "24.08",
-    "sdk": "org.freedesktop.Sdk",
-    "finish-args": [
-        "--device=dri",
-        "--share=ipc",
-        "--share=network",
-        "--socket=fallback-x11",
-        "--socket=wayland",
-        "--socket=pulseaudio",
-        "--persist=.redeclipse"
-    ],
-    "command": "redeclipse",
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/share/aclocal",
-        "/share/man",
-        "*.la",
-        "*.a"
-    ],
-    "modules": [
+id: net.redeclipse.RedEclipse-Legacy
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: redeclipse   
+finish-args:
+  - --device=dri
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --persist=.redeclipse
+  modules:
         {
             "name": "redeclipse",
             "buildsystem": "cmake-ninja",

--- a/net.redeclipse.RedEclipse-Legacy.yml
+++ b/net.redeclipse.RedEclipse-Legacy.yml
@@ -40,4 +40,4 @@ modules:
       - install -Dm644 ../net.redeclipse.RedEclipse-Legacy.appdata.xml /app/share/appdata/net.redeclipse.RedEclipse-Legacy.appdata.xml
       - install -Dm644 ../redeclipse.desktop /app/share/applications/net.redeclipse.RedEclipse-Legacy.desktop
       - install -Dm644 ../src/install/nix/redeclipse_x128.png /app/share/icons/hicolor/128x128/apps/net.redeclipse.RedEclipse-Legacy.png
-      - desktop-file-edit --set-name=\"Red Eclipse Legacy\" --set-icon=net.redeclipse.RedEclipse-Legacy --set-key=Exec --set-value=redeclipse /app/share/applications/net.redeclipse.RedEclipse-Legacy.desktop
+      - desktop-file-edit --set-name="Red Eclipse Legacy" --set-icon=net.redeclipse.RedEclipse-Legacy --set-key=Exec --set-value=redeclipse /app/share/applications/net.redeclipse.RedEclipse-Legacy.desktop


### PR DESCRIPTION
- Convert manifest to yml - much more convenient to work with.
- Remove cleanup section - there doesn't seem anything to cleanup.
- Remove server and genkey binaries as there isn't any way to launch them from the Flatpak.