### PR TITLE
Add compile flags set by upstream in build options

### DIFF
--- a/net.redeclipse.RedEclipse-Legacy.yml
+++ b/net.redeclipse.RedEclipse-Legacy.yml
@@ -16,6 +16,11 @@ modules:
   - name: redeclipse
     no-autogen: true
     no-make-install: true
+    build-options:
+      cflags: -O3 -fomit-frame-pointer -ffast-math
+      cflags-override: true
+      cxxflags: -O3 -fomit-frame-pointer -ffast-math
+      cxxflags-override: true
     subdir: src
     sources:
       - type: archive


### PR DESCRIPTION
The default buildsystem seems to ignore them