### PR TITLE
Revert last PR

### DIFF
--- a/net.redeclipse.RedEclipse-Legacy.yml
+++ b/net.redeclipse.RedEclipse-Legacy.yml
@@ -11,26 +11,7 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --persist=.redeclipse
-cleanup:
-  - /include
-  - /lib/pkgconfig
-  - '*.la'
-  - '*.a'
 modules:
-
-  - name: enet
-    sources:
-      - type: archive
-        url: https://github.com/lsalzman/enet/archive/refs/tags/v1.3.18.tar.gz
-        sha256: 28603c895f9ed24a846478180ee72c7376b39b4bb1287b73877e5eae7d96b0dd
-        x-checker-data:
-          type: anitya
-          project-id: 696
-          stable-only: true
-          url-template: https://github.com/lsalzman/enet/archive/refs/tags/v$version.tar.gz
-      - type: shell
-        commands:
-          - autoreconf -vfi
 
   - name: redeclipse
     no-autogen: true
@@ -53,7 +34,7 @@ modules:
       - type: file
         path: redeclipse.sh
       - type: patch
-        path: use-system-enet-and-sqlite.patch
+        path: use-system-sqlite.patch
     post-install:
       - install -Dm755 ../redeclipse.sh /app/bin/redeclipse
       - install -Dm755 redeclipse_linux /app/share/redeclipse/redeclipse

--- a/use-system-sqlite.patch
+++ b/use-system-sqlite.patch
@@ -1,31 +1,21 @@
-From 26d2c27df0023711feebbd5048d79dc137efb89e Mon Sep 17 00:00:00 2001
-From: user1-github <56021366+user1-github@users.noreply.github.com>
-Date: Sun, 22 Jun 2025 18:49:20 +0300
-Subject: [PATCH] Patch makefile to use both system enet and sqlite
+From: Markus Koschany <apo@debian.org>
+Date: Sat, 21 Jan 2017 05:37:25 +0100
+Subject: use system sqlite
 
 ---
- src/Makefile | 17 +++++------------
- 1 file changed, 5 insertions(+), 12 deletions(-)
+ src/Makefile | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
 
 diff --git a/src/Makefile b/src/Makefile
-index 8df1a12..9b58a68 100644
+index 8df1a12..f51b7df 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -40,7 +40,7 @@ CC_TEMP:=$(CC)
- override CXX=$(TOOLSET_PREFIX)$(CXX_TEMP)
- override CC=$(TOOLSET_PREFIX)$(CC_TEMP)
- 
--INCLUDES= -I. -Ishared -Iengine -Igame -Ienet/include -Isupport
-+INCLUDES= -I. -Ishared -Iengine -Igame -Isupport
- 
- STRIP=
- ifeq (,$(findstring -g,$(CXXFLAGS)))
 @@ -83,7 +83,7 @@ BIN_SUFFIX=_native
  endif
  endif
  CLIENT_INCLUDES= $(INCLUDES) -I/usr/X11R6/include `sdl2-config --cflags`
 -CLIENT_LIBS= -Lenet -lenet -L/usr/X11R6/lib -lX11 `sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lz -lGL
-+CLIENT_LIBS= -lenet -L/usr/X11R6/lib -lX11 `sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lz -lGL -lsqlite3
++CLIENT_LIBS= -Lenet -lenet -L/usr/X11R6/lib -lX11 `sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lz -lGL -lsqlite3
  endif
  ifneq (,$(findstring linux,$(PLATFORM)))
  CLIENT_LIBS+= -lrt
@@ -42,7 +32,7 @@ index 8df1a12..9b58a68 100644
  else
  SERVER_INCLUDES= -DSTANDALONE $(INCLUDES)
 -SERVER_LIBS= -Lenet -lenet -lz
-+SERVER_LIBS= -lenet -lz -lsqlite3
++SERVER_LIBS= -Lenet -lenet -lz -lsqlite3
  endif
  SERVER_OBJS= \
  	shared/crypto-standalone.o \
@@ -64,19 +54,6 @@ index 8df1a12..9b58a68 100644
  $(CLIENT_OBJS): CXXFLAGS += $(CLIENT_INCLUDES)
  $(filter shared/%,$(CLIENT_OBJS)): $(filter shared/%,$(CLIENT_PCH))
  $(filter engine/%,$(CLIENT_OBJS)): $(filter engine/%,$(CLIENT_PCH))
-@@ -223,10 +218,10 @@ $(APPSERVER)_windows$(BIN_SUFFIX): $(SERVER_OBJS)
- 	$(WINDRES) -i $(APPNAME).rc -J rc -o $(APPNAME).res -O coff
- 	$(CXX) $(CXXFLAGS) -o $@ $(APPNAME).res $(SERVER_OBJS) $(SERVER_LIBS)
- 
--$(APPCLIENT)$(BIN_SUFFIX): $(LIBENET) $(CLIENT_OBJS)
-+$(APPCLIENT)$(BIN_SUFFIX): $(CLIENT_OBJS)
- 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(CLIENT_OBJS) $(CLIENT_LIBS)
- 
--$(APPSERVER)$(BIN_SUFFIX): $(LIBENET) $(SERVER_OBJS)
-+$(APPSERVER)$(BIN_SUFFIX): $(SERVER_OBJS)
- 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(SERVER_OBJS) $(SERVER_LIBS)
- 
- client: $(APPCLIENT)$(APPMODIFIER)$(BIN_SUFFIX)
 @@ -389,7 +384,6 @@ engine/master.o: shared/tools.h shared/command.h shared/geom.h shared/ents.h
  engine/master.o: shared/glexts.h shared/glemu.h shared/iengine.h
  engine/master.o: shared/igame.h engine/irc.h engine/sound.h engine/world.h


### PR DESCRIPTION
Atm, there don't seem to be any benefits in forcing the game to use system enet (unlike system sqlite, since the bundled sqlite sometimes makes the game crash). So make it use only system sqlite.